### PR TITLE
Fix send method

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -82,9 +82,9 @@ proto.create_group = function(data, cb) {
 
 proto.send = function(feed_name, data, cb) {
 
-  var data = new Data(this.key, feed_name);
+  var feed_data = new Data(this.key, feed_name);
 
-  return data.send(data, cb);
+  return feed_data.send(data, cb);
 
 };
 


### PR DESCRIPTION
I am not able to use the send function without this change. The send function has a data parameter and a local var also named data. Changing the local var name fixes the function.
